### PR TITLE
[Fix] #23 落ちるようになったテストの修正

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,10 +22,10 @@ FactoryBot.define do
     password_confirmation { "password" }
 
     after(:create) do |testuser|
+      testuser.tweets.create(content: "I'm TEST_USER_1")
       30.times do |n|
         testuser.tweets.create(content: "This is No.#{n+1} message.")
       end
-      testuser.tweets.create(content: "I'm TEST_USER_1")
     end
   end
 

--- a/spec/models/user_model_spec.rb
+++ b/spec/models/user_model_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe User, type: :model do
       expect(@tweet.user_id).to eq @user.id
     end
     it "Userをdestroyすると関連付けられたTweetsもdestroyされる" do
-      # testuser に30ツイート分紐づけてあるから by(-31)で検証
-      expect{@user.destroy}.to change{Tweet.count}.by(-31)
+      # testuser に31ツイート分紐づけてあるから by(-31)で検証
+      expect{@user.destroy}.to change{Tweet.count}.by(-32)
     end
   end
 


### PR DESCRIPTION
#23 より
スペックファイルの修正が完了しました。
主にfactoryの記述を少し変更することでダミーツイートの生成順序を調整し、テストをパスできるようにしました。